### PR TITLE
Update library versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
 	  <dependency>
 	  	<groupId>org.spdx</groupId>
 	  	<artifactId>java-spdx-library</artifactId>
-	  	<version>1.0.6</version>
+	  	<version>1.0.7</version>
 	  </dependency>
 	  <dependency>
 	  	<groupId>org.spdx</groupId>
@@ -122,12 +122,12 @@
 	  <dependency>
 	  	<groupId>org.spdx</groupId>
 	  	<artifactId>spdx-spreadsheet-store</artifactId>
-	  	<version>1.0.0</version>
+	  	<version>1.0.1</version>
 	  </dependency>
 	  <dependency>
 	  	<groupId>org.spdx</groupId>
 	  	<artifactId>spdx-tagvalue-store</artifactId>
-	  	<version>1.0.1</version>
+	  	<version>1.0.2</version>
 	  </dependency>
 	</dependencies>
     <build>

--- a/src/main/java/org/spdx/tools/SpdxConverter.java
+++ b/src/main/java/org/spdx/tools/SpdxConverter.java
@@ -173,7 +173,7 @@ public class SpdxConverter {
 		} catch (Exception ex) {
 			String msg = "Error converting SPDX file: "+ex.getClass().toString();
 			if (Objects.nonNull(ex.getMessage())) {
-				msg = msg + ex.getMessage();
+				msg = msg + " " + ex.getMessage();
 			}
 			throw new SpdxConverterException(msg, ex);
 		} finally {


### PR DESCRIPTION
Update library versions to the latest - resolves significant performance problem when parsing large SPDX files.

Also fixes a formatting issues for error text in the compare utility.