### PR TITLE
Update link to SPDX online tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ The following tool can be used to generate an SPDX verification code from a dire
         java -jar spdx-tools-jar-with-dependencies.jar GenerateVerificationCode sourceDirectory [ignoredFilesRegex]
 
 ## SPDX Validation Tool
-The SPDX Workgroup provides an online interface to validate, compare, and convert SPDX documents in addition to the command line options above. The [SPDX Validation Tool](http://13.57.134.254/app/) is an all-in-one portal to upload and parse SPDX documents for validation, comparison and conversion and search the SPDX license list. 
+The SPDX Workgroup provides an online interface to validate, compare, and convert SPDX documents in addition to the command line options above. The [SPDX Validation Tool](https://tools.spdx.org/app/validate/) is an all-in-one portal to upload and parse SPDX documents for validation, comparison and conversion and search the SPDX license list. 
 
 # License
 A complete SPDX file is available including dependencies is available in the bintray and Maven repos.


### PR DESCRIPTION
The readme had a broken link to the SPDX online tool - I presume it should link to https://tools.spdx.org/app/validate/? I changed the readme link for this PR