### PR TITLE
Update JSON schema

### DIFF
--- a/resources/spdx-schema-v2.3.json
+++ b/resources/spdx-schema-v2.3.json
@@ -322,14 +322,14 @@
                 "referenceCategory" : {
                   "description" : "Category for the external reference",
                   "type" : "string",
-                  "enum" : [ "OTHER", "PERSISTENT-ID", "SECURITY", "PACKAGE-MANAGER" ]
+                  "enum" : [ "OTHER", "PERSISTENT-ID", "PERSISTENT_ID", "SECURITY", "PACKAGE-MANAGER", "PACKAGE_MANAGER" ]
                 },
                 "referenceLocator" : {
                   "description" : "The unique string with no spaces necessary to access the package-specific information, metadata, or content within the target location. The format of the locator is subject to constraints defined by the <type>.",
                   "type" : "string"
                 },
                 "referenceType" : {
-                  "description" : "Type of the external reference. These are definined in an appendix in the SPDX specification.",
+                  "description" : "Type of the external reference. These are defined in an appendix in the SPDX specification.",
                   "type" : "string"
                 }
               },

--- a/src/test/java/org/spdx/tools/VerifyTest.java
+++ b/src/test/java/org/spdx/tools/VerifyTest.java
@@ -68,7 +68,7 @@ public class VerifyTest extends TestCase {
 	
 	public void testVerifyBadJSON() throws SpdxVerificationException {
 		List<String> result = Verify.verify(BAD_JSON_FILE_PATH, SerFileType.JSON);
-		assertTrue(result.size() == 5);
+		assertTrue(result.size() == 4);
 	}
 	
 	// Test specific spec versions for the JSON format


### PR DESCRIPTION
Allows for both dashes and underscores in enumeration values

Supports spec resolution for https://github.com/spdx/spdx-spec/issues/792

Signed-off-by: Gary O'Neall <gary@sourceauditor.com>