### PR TITLE
Update SPDX libraries to version 1.1.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,7 @@
 	  <sonar.organization>spdx</sonar.organization>
 	  <sonar.projectKey>tools-java</sonar.projectKey>
 	  <dependency-check-maven.version>8.0.1</dependency-check-maven.version>
+	  <maven.compiler.release>11</maven.compiler.release>
 	  <javadoc.opts>-Xdoclint:none</javadoc.opts>
     </properties>
 	<profiles>
@@ -95,17 +96,17 @@
 	  <dependency>
 	  	<groupId>org.spdx</groupId>
 	  	<artifactId>java-spdx-library</artifactId>
-	  	<version>1.1.3</version>
+	  	<version>1.1.4</version>
 	  </dependency>
 	  <dependency>
 	  	<groupId>org.spdx</groupId>
 	  	<artifactId>spdx-rdf-store</artifactId>
-	  	<version>1.1.3</version>
+	  	<version>1.1.4</version>
 	  </dependency>
 	  <dependency>
 	  	<groupId>org.spdx</groupId>
 	  	<artifactId>spdx-jackson-store</artifactId>
-	  	<version>1.1.3</version>
+	  	<version>1.1.4</version>
 	  </dependency>
 	  <dependency>
 	  	<groupId>org.apache.ws.xmlschema</groupId>
@@ -115,12 +116,12 @@
 	  <dependency>
 	  	<groupId>org.spdx</groupId>
 	  	<artifactId>spdx-spreadsheet-store</artifactId>
-	  	<version>1.1.3</version>
+	  	<version>1.1.4</version>
 	  </dependency>
 	  <dependency>
 	  	<groupId>org.spdx</groupId>
 	  	<artifactId>spdx-tagvalue-store</artifactId>
-	  	<version>1.1.3</version>
+	  	<version>1.1.4</version>
 	  </dependency>
 	  <dependency>
 	  	<groupId>com.github.java-json-tools</groupId>
@@ -177,12 +178,31 @@
    					<suppressionFiles>dependency-check-supress.xml</suppressionFiles>
    				</configuration>
 			</plugin>
+		    <plugin>
+		      <groupId>org.apache.maven.plugins</groupId>
+		      <artifactId>maven-enforcer-plugin</artifactId>
+		      <version>3.2.1</version>
+		      <executions>
+		        <execution>
+		          <id>enforce-java</id>
+		          <goals>
+		            <goal>enforce</goal>
+		          </goals>
+		          <configuration>
+		            <rules>
+		              <requireJavaVersion>
+		                <version>${maven.compiler.release}</version>
+		              </requireJavaVersion>
+		            </rules>    
+		          </configuration>
+		        </execution>
+		      </executions>
+		    </plugin>	
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.6.1</version>
 				<configuration>
-					<release>11</release>
 					<encoding>${project.build.sourceEncoding}</encoding>
 					<showDeprecation>true</showDeprecation>
 					<showWarnings>true</showWarnings>


### PR DESCRIPTION
This PR also updates the POM file to enforce Java 11 which is required due to an indirect dependency on Apache Jena

Signed-off-by: Gary O'Neall <gary@sourceauditor.com>