### PR TITLE
Catch JSON exceptions in verify

### DIFF
--- a/src/main/java/org/spdx/tools/Verify.java
+++ b/src/main/java/org/spdx/tools/Verify.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
+import com.fasterxml.jackson.core.JsonParseException;
 import org.spdx.library.InvalidSPDXAnalysisException;
 import org.spdx.library.Version;
 import org.spdx.library.model.SpdxDocument;
@@ -126,6 +127,8 @@ public class Verify {
 			doc = SpdxToolsHelper.readDocumentFromFile(store, file);
 		} catch (FileNotFoundException e) {
 			throw new SpdxVerificationException("File "+filePath+ " not found.",e);
+		} catch (JsonParseException e) {
+			throw new SpdxVerificationException("Invalid JSON file: "+e.getMessage(), e);
 		} catch (IOException e) {
 			throw new SpdxVerificationException("IO Error reading SPDX file",e);
 		} catch (InvalidSPDXAnalysisException e) {


### PR DESCRIPTION
Improves error messages.  Previously, a JSON parsing error would be reported as a file I/O error.