### PR TITLE
adding slf4j-simple as a dependency, as uber jar won't allow using it via classpath

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -143,9 +143,10 @@
 	  	<version>2.2.14</version>
 	  </dependency>
 	  <dependency>
-	    <groupId>org.slf4j</groupId>
-	    <artifactId>slf4j-simple</artifactId>
-	    <version>2.0.7</version>
+	  	<groupId>org.slf4j</groupId>
+	  	<artifactId>slf4j-simple</artifactId>
+	  	<version>2.0.7</version>
+	  	<optional>true</optional>
 	  </dependency>
 	</dependencies>
     <build>
@@ -277,6 +278,11 @@
 			                    <exclude>META-INF/*.DSA</exclude>
 			                    <exclude>META-INF/*.RSA</exclude>
 			                </excludes>
+							<artifact>org.slf4j:slf4j-simple</artifact>
+							<includes>
+								<include>org/slf4j/**</include>
+								<include>META-INF/services/**</include>
+							</includes>
 			            </filter>
 			        </filters>
 			    </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -142,6 +142,11 @@
 	  	<artifactId>json-schema-validator</artifactId>
 	  	<version>2.2.14</version>
 	  </dependency>
+	  <dependency>
+	    <groupId>org.slf4j</groupId>
+	    <artifactId>slf4j-simple</artifactId>
+	    <version>2.0.7</version>
+	  </dependency>
 	</dependencies>
     <build>
   		<resources>


### PR DESCRIPTION
fixes #153 (hopefully)
Merge this pull request only if tools-java is used as a command line tool and is not intended to be used as a maven dependency for other artifacts. If so, this fix will force the use of slf4j-simple (console logging) in the other artifact (or requires <excludes>).

For the explanation related to comments in #153 : when using the uberjar / jar-with-dependencies, it is not enough to add slf4j-simple in the classpath. The reason is that some `org.slf4j` package exists inside the produced jar with dependencies. So, adding `slf4j-simple` to the classpath is probably ignored, but when added as a maven dependency, it will be included in the `jar-with-dependencies` and it will work.

The result of some `Verfify` with the built jar does not include the fl4j warning anymore and will now include some WARNings issued by spdx tooling:
```
 java -jar target/tools-java-1.1.9-SNAPSHOT-jar-with-dependencies.jar Verify testResources/SPDXTagExample-v2.3.spdx 
[main] WARN org.spdx.library.model.SpdxElement - No creation info for document Optional[SPDX-Tools-v2.0]
[main] WARN org.spdx.library.model.SimpleUriValue - URI http://spdx.org/spdxdocs/spdx-example-tv-2-3-444504E0-4F89-41D3-9A0C-0305E82C3301#LocationRef-acmeforge does not match any model object or enumeration
[main] WARN org.spdx.library.model.SimpleUriValue - URI http://spdx.org/spdxdocs/spdx-example-tv-2-3-444504E0-4F89-41D3-9A0C-0305E82C3301#LocationRef-acmeforge does not match any model object or enumeration
[main] WARN org.spdx.library.model.SimpleUriValue - URI http://spdx.org/spdxdocs/spdx-example-tv-2-3-444504E0-4F89-41D3-9A0C-0305E82C3301#LocationRef-acmeforge does not match any model object or enumeration
[main] WARN org.spdx.library.model.SimpleUriValue - URI http://spdx.org/spdxdocs/spdx-example-tv-2-3-444504E0-4F89-41D3-9A0C-0305E82C3301#LocationRef-acmeforge does not match any model object or enumeration
[main] WARN org.spdx.library.model.SimpleUriValue - URI http://spdx.org/spdxdocs/spdx-example-tv-2-3-444504E0-4F89-41D3-9A0C-0305E82C3301#LocationRef-acmeforge does not match any model object or enumeration
[main] WARN org.spdx.library.model.SimpleUriValue - URI http://spdx.org/spdxdocs/spdx-example-tv-2-3-444504E0-4F89-41D3-9A0C-0305E82C3301#LocationRef-acmeforge does not match any model object or enumeration
[main] WARN org.spdx.library.model.SimpleUriValue - URI http://spdx.org/spdxdocs/spdx-example-tv-2-3-444504E0-4F89-41D3-9A0C-0305E82C3301#LocationRef-acmeforge does not match any model object or enumeration
[main] WARN org.spdx.library.model.SimpleUriValue - URI http://spdx.org/spdxdocs/spdx-example-tv-2-3-444504E0-4F89-41D3-9A0C-0305E82C3301#LocationRef-acmeforge does not match any model object or enumeration
[main] WARN org.spdx.library.model.SimpleUriValue - URI http://spdx.org/spdxdocs/spdx-example-tv-2-3-444504E0-4F89-41D3-9A0C-0305E82C3301#LocationRef-acmeforge does not match any model object or enumeration
This SPDX Document is valid.
```

If you wish to remove the warnings, then probably a logback config file needs to be added to set the default log level to ERROR.