### PR TITLE
Handle null before access to creation info / license info

### DIFF
--- a/src/main/java/org/spdx/tools/MatchingStandardLicenses.java
+++ b/src/main/java/org/spdx/tools/MatchingStandardLicenses.java
@@ -53,6 +53,7 @@ public class MatchingStandardLicenses {
 			usage();
 			System.exit(ERROR_STATUS);
 		}
+		@SuppressWarnings("null")
 		File textFile = new File(args[0]);
 
 		if (!textFile.exists()) {

--- a/src/main/java/org/spdx/tools/Verify.java
+++ b/src/main/java/org/spdx/tools/Verify.java
@@ -96,7 +96,7 @@ public class Verify {
 		// separate out the warning from errors
 		List<String> warnings = new ArrayList<String>();
 		List<String> errors = new ArrayList<String>();
-		for (String verifyMsg: verify) {
+		for (String verifyMsg : verify) {
 			if (verifyMsg.contains(" is deprecated.")) {
 				warnings.add(verifyMsg);
 			} else {

--- a/src/main/java/org/spdx/tools/Verify.java
+++ b/src/main/java/org/spdx/tools/Verify.java
@@ -94,7 +94,7 @@ public class Verify {
 			System.exit(ERROR_STATUS);
 		}
 		// separate out the warning from errors
-		List<String> warnings = new ArrayList<String>();
+		List<String> warnings = new ArrayList<>();
 		List<String> errors = new ArrayList<String>();
 		for (String verifyMsg : verify) {
 			if (verifyMsg.contains(" is deprecated.")) {

--- a/src/main/java/org/spdx/tools/Verify.java
+++ b/src/main/java/org/spdx/tools/Verify.java
@@ -95,7 +95,7 @@ public class Verify {
 		}
 		// separate out the warning from errors
 		List<String> warnings = new ArrayList<>();
-		List<String> errors = new ArrayList<String>();
+		List<String> errors = new ArrayList<>();
 		for (String verifyMsg : verify) {
 			if (verifyMsg.contains(" is deprecated.")) {
 				warnings.add(verifyMsg);

--- a/src/main/java/org/spdx/tools/Verify.java
+++ b/src/main/java/org/spdx/tools/Verify.java
@@ -86,7 +86,6 @@ public class Verify {
 				fileType = SpdxToolsHelper.fileToFileType(new File(args[0]));
 			}
 			verify = verify(args[0], fileType);
-			
 		} catch (SpdxVerificationException e) {
 			System.out.println(e.getMessage());
 			System.exit(ERROR_STATUS);
@@ -95,9 +94,9 @@ public class Verify {
 			System.exit(ERROR_STATUS);
 		}
 		// separate out the warning from errors
-		List<String> warnings = new ArrayList<>();
-		List<String> errors = new ArrayList<>();
-		for (String verifyMsg:verify) {
+		List<String> warnings = new ArrayList<String>();
+		List<String> errors = new ArrayList<String>();
+		for (String verifyMsg: verify) {
 			if (verifyMsg.contains(" is deprecated.")) {
 				warnings.add(verifyMsg);
 			} else {

--- a/src/main/java/org/spdx/tools/compare/CreatorSheet.java
+++ b/src/main/java/org/spdx/tools/compare/CreatorSheet.java
@@ -26,6 +26,7 @@ import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.Workbook;
 import org.spdx.core.InvalidSPDXAnalysisException;
+import org.spdx.library.model.v2.SpdxCreatorInformation;
 import org.spdx.utility.compare.SpdxCompareException;
 import org.spdx.utility.compare.SpdxComparer;
 
@@ -90,15 +91,18 @@ public class CreatorSheet extends AbstractSheet {
 		for (int i = 0; i < comparer.getNumSpdxDocs(); i++) {
 			Cell headerCell = header.getCell(i);
 			headerCell.setCellValue(docNames.get(i));
-			String[] creators = comparer.getSpdxDoc(i).getCreationInfo().getCreators().toArray(new String[comparer.getSpdxDoc(i).getCreationInfo().getCreators().size()]);
-			Arrays.sort(creators);
-			for (int j = 0; j < creators.length; j++) {
-				Cell creatorCell = null;
-				while (j+1 > this.getNumDataRows()) {
-					this.addRow();
+			SpdxCreatorInformation creationInfo = comparer.getSpdxDoc(i).getCreationInfo();
+			if (creationInfo != null) {
+				String[] creators = creationInfo.getCreators().toArray(new String[creationInfo.getCreators().size()]);
+				Arrays.sort(creators);
+				for (int j = 0; j < creators.length; j++) {
+					Cell creatorCell = null;
+					while (j+1 > this.getNumDataRows()) {
+						this.addRow();
+					}
+					creatorCell = sheet.getRow(j+1).createCell(i);
+					creatorCell.setCellValue(creators[j]);
 				}
-				creatorCell = sheet.getRow(j+1).createCell(i);
-				creatorCell.setCellValue(creators[j]);
 			}
 		}
 	}

--- a/src/main/java/org/spdx/tools/compare/DocumentSheet.java
+++ b/src/main/java/org/spdx/tools/compare/DocumentSheet.java
@@ -26,11 +26,12 @@ import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.Workbook;
 import org.spdx.core.InvalidSPDXAnalysisException;
+import org.spdx.library.model.v2.SpdxCreatorInformation;
 import org.spdx.utility.compare.SpdxCompareException;
 import org.spdx.utility.compare.SpdxComparer;
 
 /**
- * Sheet to hold compare information at the docment level:
+ * Sheet to hold compare information at the document level:
  * 		Created, Data License, Document Comment
  * The first row summarizes which fields are different, the subsequent rows are the
  * specific date from each result
@@ -254,9 +255,12 @@ public class DocumentSheet extends AbstractSheet {
 		// data rows
 		for (int i = 0; i < comparer.getNumSpdxDocs(); i++) {
 			cell = sheet.getRow(getFirstDataRow()+i+1).createCell(LICENSE_LIST_VERSION_COL);
-			Optional<String> licenseListVersion = comparer.getSpdxDoc(i).getCreationInfo().getLicenseListVersion();
-			if (licenseListVersion.isPresent()) {
-				cell.setCellValue(licenseListVersion.get());
+			SpdxCreatorInformation creationInfo = comparer.getSpdxDoc(i).getCreationInfo();
+			if (creationInfo != null) {
+				Optional<String> licenseListVersion = creationInfo.getLicenseListVersion();
+				if (licenseListVersion.isPresent()) {
+					cell.setCellValue(licenseListVersion.get());
+				}
 			}
 		}
 	}
@@ -340,11 +344,13 @@ public class DocumentSheet extends AbstractSheet {
 		// data rows
 		for (int i = 0; i < comparer.getNumSpdxDocs(); i++) {
 			cell = sheet.getRow(getFirstDataRow()+i+1).createCell(CREATOR_COMMENT_COL);
-			Optional<String> creatorComment = comparer.getSpdxDoc(i).getCreationInfo().getComment();
-			if (creatorComment.isPresent()) {
-				cell.setCellValue(creatorComment.get());
+			SpdxCreatorInformation creationInfo = comparer.getSpdxDoc(i).getCreationInfo();
+			if (creationInfo != null) {
+				Optional<String> creatorComment = creationInfo.getComment();
+				if (creatorComment.isPresent()) {
+					cell.setCellValue(creatorComment.get());
+				}
 			}
-			
 		}
 	}
 
@@ -364,7 +370,10 @@ public class DocumentSheet extends AbstractSheet {
 		// data rows
 		for (int i = 0; i < comparer.getNumSpdxDocs(); i++) {
 			cell = sheet.getRow(getFirstDataRow()+i+1).createCell(CREATION_DATE_COL);
-			cell.setCellValue(comparer.getSpdxDoc(i).getCreationInfo().getCreated());
+			SpdxCreatorInformation creationInfo = comparer.getSpdxDoc(i).getCreationInfo();
+			if (creationInfo != null) {
+				cell.setCellValue(creationInfo.getCreated());
+			}
 		}
 	}
 

--- a/src/main/java/org/spdx/tools/compare/PackageSheet.java
+++ b/src/main/java/org/spdx/tools/compare/PackageSheet.java
@@ -35,6 +35,7 @@ import org.spdx.core.InvalidSPDXAnalysisException;
 import org.spdx.library.model.v2.SpdxDocument;
 import org.spdx.library.model.v2.SpdxPackage;
 import org.spdx.library.model.v2.SpdxPackageVerificationCode;
+import org.spdx.library.model.v2.license.AnyLicenseInfo;
 import org.spdx.utility.compare.SpdxCompareException;
 import org.spdx.utility.compare.SpdxComparer;
 import org.spdx.utility.compare.SpdxPackageComparer;
@@ -404,7 +405,10 @@ public class PackageSheet extends AbstractSheet {
 				}
 				concludedLicenseRow.createCell(FIRST_DOC_COL+i).setCellValue(pkg.getLicenseConcluded().toString());
 				licenseInfosFromFilesRow.createCell(FIRST_DOC_COL+i).setCellValue(CompareHelper.licenseInfosToString(pkg.getLicenseInfoFromFiles()));
-				declaredLicenseRow.createCell(FIRST_DOC_COL+i).setCellValue(pkg.getLicenseDeclared().toString());
+				AnyLicenseInfo licenseDeclared = pkg.getLicenseDeclared();
+				if (licenseDeclared != null) {
+					declaredLicenseRow.createCell(FIRST_DOC_COL+i).setCellValue(licenseDeclared.toString());
+				}
 				Optional<String> licenseComments = pkg.getLicenseComments();
 				if (licenseComments.isPresent()) {
 					licenseCommentRow.createCell(FIRST_DOC_COL+i).setCellValue(licenseComments.get());

--- a/testResources/sourcefiles/DocumentSheet.java
+++ b/testResources/sourcefiles/DocumentSheet.java
@@ -29,7 +29,7 @@ import org.spdx.utility.compare.SpdxCompareException;
 import org.spdx.utility.compare.SpdxComparer;
 
 /**
- * Sheet to hold compare information at the docment level:
+ * Sheet to hold compare information at the document level:
  * 		Created, Data License, Document Comment
  * The first row summarizes which fields are different, the subsequent rows are the
  * specific date from each result


### PR DESCRIPTION
- Check if a return value from `getCreationInfo()` or `getLicenseDeclared()` is null before access.
- Suppress one null warning for a command line that null is already checked