### PR TITLE
Update SPDX libraries version in POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -155,18 +155,18 @@
 	  <dependency>
 	  	<groupId>com.networknt</groupId>
 	  	<artifactId>json-schema-validator</artifactId>
-	  	<version>1.5.1</version>
+	  	<version>1.5.6</version>
 	  </dependency>
 	  <dependency>
 	  	<groupId>org.slf4j</groupId>
 	  	<artifactId>slf4j-simple</artifactId>
-	  	<version>2.0.13</version>
+	  	<version>2.0.17</version>
 	  	<optional>true</optional>
 	  </dependency>
 		<dependency>
 			<groupId>org.apache.poi</groupId>
 			<artifactId>poi</artifactId>
-			<version>5.3.0</version>
+			<version>5.4.1</version>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -112,6 +112,11 @@
 	    <version>1.27.1</version>
 	  </dependency>
 	  <dependency>
+	  	<groupId>org.apache.ws.xmlschema</groupId>
+	  	<artifactId>xmlschema-core</artifactId>
+	  	<version>2.3.0</version>
+	  </dependency>
+	  <dependency>
 	    <groupId>junit</groupId>
 	    <artifactId>junit</artifactId>
 	    <version>4.13.1</version>
@@ -120,32 +125,32 @@
 	  <dependency>
 	  	<groupId>org.spdx</groupId>
 	  	<artifactId>java-spdx-library</artifactId>
-	  	<version>2.0.0-RC2</version>
+	  	<version>2.0.0</version>
 	  </dependency>
 	  <dependency>
 	  	<groupId>org.spdx</groupId>
 	  	<artifactId>spdx-rdf-store</artifactId>
-	  	<version>2.0.0-RC2</version>
+	  	<version>2.0.0</version>
 	  </dependency>
 	  <dependency>
 	  	<groupId>org.spdx</groupId>
 	  	<artifactId>spdx-jackson-store</artifactId>
-	  	<version>2.0.0-RC2</version>
-	  </dependency>
-	  <dependency>
-	  	<groupId>org.apache.ws.xmlschema</groupId>
-	  	<artifactId>xmlschema-core</artifactId>
-	  	<version>2.3.0</version>
+	  	<version>2.0.0</version>
 	  </dependency>
 	  <dependency>
 	  	<groupId>org.spdx</groupId>
 	  	<artifactId>spdx-spreadsheet-store</artifactId>
-	  	<version>2.0.0-RC2</version>
+	  	<version>2.0.0</version>
 	  </dependency>
 	  <dependency>
 	  	<groupId>org.spdx</groupId>
 	  	<artifactId>spdx-tagvalue-store</artifactId>
-	  	<version>2.0.0-RC2</version>
+	  	<version>2.0.0</version>
+	  </dependency>
+	  <dependency>
+	  	<groupId>org.spdx</groupId>
+	  	<artifactId>spdx-v3jsonld-store</artifactId>
+	  	<version>1.0.0</version>
 	  </dependency>
 	  <dependency>
 	  	<groupId>com.networknt</groupId>
@@ -157,11 +162,6 @@
 	  	<artifactId>slf4j-simple</artifactId>
 	  	<version>2.0.13</version>
 	  	<optional>true</optional>
-	  </dependency>
-	  <dependency>
-	  	<groupId>org.spdx</groupId>
-	  	<artifactId>spdx-v3jsonld-store</artifactId>
-	  	<version>1.0.0-RC3</version>
 	  </dependency>
 		<dependency>
 			<groupId>org.apache.poi</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -166,7 +166,7 @@
 		<dependency>
 			<groupId>org.apache.poi</groupId>
 			<artifactId>poi</artifactId>
-			<version>5.3.0</version>
+			<version>5.4.1</version>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -114,12 +114,12 @@
 	  <dependency>
 	  	<groupId>org.apache.ws.xmlschema</groupId>
 	  	<artifactId>xmlschema-core</artifactId>
-	  	<version>2.3.0</version>
+	  	<version>2.3.1</version>
 	  </dependency>
 	  <dependency>
 	    <groupId>junit</groupId>
 	    <artifactId>junit</artifactId>
-	    <version>4.13.1</version>
+	    <version>4.13.2</version>
 	    <scope>test</scope>
 	  </dependency>
 	  <dependency>
@@ -166,7 +166,7 @@
 		<dependency>
 			<groupId>org.apache.poi</groupId>
 			<artifactId>poi</artifactId>
-			<version>5.4.1</version>
+			<version>5.3.0</version>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
- java-spdx-library to 2.0.0
- spdx-rdf-store to 2.0.0
- spdx-jackson-store to 2.0.0
- spdx-spreadsheet-store to 2.0.0
- spdx-tagvalue-store to 2.0.0
- spdx-v3jsonld-store to 1.0.0
- Update other dependencies to the their latest patch version
- Update org.apache.poi/poi from 5.3.0 to 5.4.1 to fix errors in 4 tests