### PR TITLE
Fix Shade plugin version to 3.2.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -285,7 +285,8 @@
 		    <plugin>
 			    <groupId>org.apache.maven.plugins</groupId>
 			    <artifactId>maven-shade-plugin</artifactId>
-				<version>3.4.1</version>
+				<version>3.2.4</version>
+				<!-- DO NOT USE LATER VERSIONS OF THE SHADE PLUGIN - SEE ISSUE 201 FOR CONTEXT -->
 			    <configuration>
 			        <shadedArtifactAttached>true</shadedArtifactAttached>
 			        <shadedClassifierName>jar-with-dependencies</shadedClassifierName>


### PR DESCRIPTION
Fixes #201

Later versions of the shade plugin strip out the dependencies in the POM file.