### PR TITLE
spdx-schema-v2.3.json: fix OPERATING-SYSTEM package intent

### DIFF
--- a/resources/spdx-schema-v2.3.json
+++ b/resources/spdx-schema-v2.3.json
@@ -413,7 +413,7 @@
           "primaryPackagePurpose" : {
             "description" : "This field provides information about the primary purpose of the identified package. Package Purpose is intrinsic to how the package is being used rather than the content of the package.",
             "type" : "string",
-            "enum" : [ "OTHER", "INSTALL", "ARCHIVE", "FIRMWARE", "APPLICATION", "FRAMEWORK", "LIBRARY", "CONTAINER", "SOURCE", "DEVICE", "OPERATING_SYSTEM", "FILE" ]
+            "enum" : [ "OTHER", "INSTALL", "ARCHIVE", "FIRMWARE", "APPLICATION", "FRAMEWORK", "LIBRARY", "CONTAINER", "SOURCE", "DEVICE", "OPERATING-SYSTEM", "FILE" ]
           },
           "releaseDate" : {
             "description" : "This field provides a place for recording the date the package was released.",


### PR DESCRIPTION
For Wolfi container at cgr.dev/chainguard/wolfi-base, trivy for spdx json SBOM generates

```json
    {
      "name": "wolfi",
      "SPDXID": "SPDXRef-OperatingSystem-2bccf727fe0bc7f8",
      "versionInfo": "20230201",
      "downloadLocation": "NONE",
      "filesAnalyzed": false,
      "primaryPackagePurpose": "OPERATING-SYSTEM",
      "annotations": [
        {
          "annotator": "Tool: trivy-0.62.1",
          "annotationDate": "2025-05-28T17:07:25Z",
          "annotationType": "OTHER",
          "comment": "Class: os-pkgs"
        },
        {
          "annotator": "Tool: trivy-0.62.1",
          "annotationDate": "2025-05-28T17:07:25Z",
          "annotationType": "OTHER",
          "comment": "Type: wolfi"
        }
      ]
    }
```

Which fails validating with tools-java because "OPERATING-SYSTEM" value is with a dash, which matches the spec at https://spdx.github.io/spdx-spec/v2.3/package-information/#724-primary-package-purpose-field

Given tools in wild follow the spec, imho it is relatively safe to update the schema here.

Note we have PACKAGE_MANAGER PACKAGE-MANAGER saga before, so do help
me validating any other tools that might be impacted, so far I see
this schema file being the only one out of line.
