### PR TITLE
Update dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # SPDX Tools
 
-
 [![Maven Central Version](https://img.shields.io/maven-central/v/org.spdx/tools-java)](https://central.sonatype.com/artifact/org.spdx/tools-java)
 [![javadoc](https://javadoc.io/badge2/org.spdx/tools-java/javadoc.svg)](https://javadoc.io/doc/org.spdx/tools-java)
 
@@ -28,7 +27,7 @@ This utility supports versions 2.0, 2.1, 2.2, 2.3 and 3.0.1 of the SPDX specific
 
 ## Getting Starting
 
-The SPDX Tools binaries can be downloaded from the [releases page](https://github.com/spdx/tools-java/releases) under the respective release.  The package is also available in [Maven Central](https://search.maven.org/artifact/org.spdx/tools-java) (organization org.spdx, artifact tools-java).
+The SPDX Tools binaries can be downloaded from the [releases page](https://github.com/spdx/tools-java/releases) under the respective release.  The package is also available in [Maven Central](https://central.sonatype.com/artifact/org.spdx/tools-java) (organization `org.spdx`, artifact `tools-java`).
 
 See the Syntax section below for the commands available.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # SPDX Tools
 
+
+[![Maven Central Version](https://img.shields.io/maven-central/v/org.spdx/tools-java)](https://central.sonatype.com/artifact/org.spdx/tools-java)
 [![javadoc](https://javadoc.io/badge2/org.spdx/tools-java/javadoc.svg)](https://javadoc.io/doc/org.spdx/tools-java)
 
 A command-line utility for creating, converting, comparing,

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
 	  <sonar.host.url>https://sonarcloud.io</sonar.host.url>
 	  <sonar.organization>spdx</sonar.organization>
 	  <sonar.projectKey>tools-java</sonar.projectKey>
-	  <dependency-check-maven.version>12.1.3</dependency-check-maven.version>
+	  <dependency-check-maven.version>12.1.6</dependency-check-maven.version>
 	  <maven.compiler.release>11</maven.compiler.release>
 	  <javadoc.opts>-Xdoclint:none</javadoc.opts>
     </properties>
@@ -67,7 +67,7 @@
 				   	<plugin>
 				      <groupId>org.apache.maven.plugins</groupId>
 				      <artifactId>maven-source-plugin</artifactId>
-				      <version>3.2.1</version>
+				      <version>3.3.1</version>
 				      <executions>
 				        <execution>
 				          <id>attach-sources</id>
@@ -104,12 +104,12 @@
 	  <dependency>
 	    <groupId>commons-io</groupId>
 	    <artifactId>commons-io</artifactId>
-	    <version>2.16.1</version>
+	    <version>2.20.0</version>
 	  </dependency>
 	  <dependency>
 	    <groupId>org.apache.commons</groupId>
 	    <artifactId>commons-compress</artifactId>
-	    <version>1.27.1</version>
+	    <version>1.28.0</version>
 	  </dependency>
 	  <dependency>
 	  	<groupId>org.apache.ws.xmlschema</groupId>
@@ -125,37 +125,37 @@
 	  <dependency>
 	  	<groupId>org.spdx</groupId>
 	  	<artifactId>java-spdx-library</artifactId>
-	  	<version>2.0.0</version>
+	  	<version>2.0.1</version>
 	  </dependency>
 	  <dependency>
 	  	<groupId>org.spdx</groupId>
 	  	<artifactId>spdx-jackson-store</artifactId>
-	  	<version>2.0.2</version>
+	  	<version>2.0.3</version>
 	  </dependency>
 	  <dependency>
 	  	<groupId>org.spdx</groupId>
 	  	<artifactId>spdx-rdf-store</artifactId>
-	  	<version>2.0.0</version>
+	  	<version>2.0.1</version>
 	  </dependency>
 	  <dependency>
 	  	<groupId>org.spdx</groupId>
 	  	<artifactId>spdx-spreadsheet-store</artifactId>
-	  	<version>2.0.0</version>
+	  	<version>2.0.1</version>
 	  </dependency>
 	  <dependency>
 	  	<groupId>org.spdx</groupId>
 	  	<artifactId>spdx-tagvalue-store</artifactId>
-	  	<version>2.0.0</version>
+	  	<version>2.0.1</version>
 	  </dependency>
 	  <dependency>
 	  	<groupId>org.spdx</groupId>
 	  	<artifactId>spdx-v3jsonld-store</artifactId>
-	  	<version>1.0.0</version>
+	  	<version>1.0.1</version>
 	  </dependency>
 	  <dependency>
 	  	<groupId>com.networknt</groupId>
 	  	<artifactId>json-schema-validator</artifactId>
-	  	<version>1.5.6</version>
+	  	<version>1.5.9</version>
 	  </dependency>
 	  <dependency>
 	  	<groupId>org.slf4j</groupId>
@@ -172,7 +172,7 @@
 		<dependency>
 			<groupId>org.apache.jena</groupId>
 			<artifactId>jena-core</artifactId>
-			<version>5.2.0</version>
+			<version>5.5.0</version>
 			<scope>compile</scope>
 		</dependency>
 	</dependencies>
@@ -232,7 +232,7 @@
 		    <plugin>
 		      <groupId>org.apache.maven.plugins</groupId>
 		      <artifactId>maven-enforcer-plugin</artifactId>
-		      <version>3.2.1</version>
+		      <version>3.6.1</version>
 		      <executions>
 		        <execution>
 		          <id>enforce-java</id>
@@ -252,7 +252,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.11.0</version>
+				<version>3.14.1</version>
 				<configuration>
 					<encoding>${project.build.sourceEncoding}</encoding>
 					<showDeprecation>true</showDeprecation>
@@ -263,7 +263,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>2.9.1</version>
+				<version>2.10.4</version>
 				<configuration>
 					<quiet>true</quiet>
 					<source>8</source>
@@ -328,7 +328,7 @@
 			<plugin>
 				<groupId>org.spdx</groupId>
 					<artifactId>spdx-maven-plugin</artifactId>
-					<version>1.0.2</version>
+					<version>1.0.3</version>
 					<executions>
 						<execution>
 							<id>build-spdx</id>

--- a/pom.xml
+++ b/pom.xml
@@ -172,7 +172,7 @@
 		<dependency>
 			<groupId>org.apache.jena</groupId>
 			<artifactId>jena-core</artifactId>
-			<version>5.5.0</version>
+			<version>5.4.0</version>
 			<scope>compile</scope>
 		</dependency>
 	</dependencies>


### PR DESCRIPTION
Update dependencies to latest minor update, including ones from SPDX Java libraries.

Except two:

- org.apache.maven.plugins:maven-shade-plugin, later versions of the shade plugin strip out the dependencies in the POM file - see #201 and #202
- org.apache.jena:jena-core, there's an issue with `org.apache.jena.assembler.ConstAssembler`, see [CI log](https://github.com/spdx/tools-java/actions/runs/17865509575/job/50806711605?pr=218) in PR #218 
