### PR TITLE
Remove redundant dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -163,18 +163,6 @@
 	  	<version>2.0.17</version>
 	  	<optional>true</optional>
 	  </dependency>
-		<dependency>
-			<groupId>org.apache.poi</groupId>
-			<artifactId>poi</artifactId>
-			<version>5.4.1</version>
-			<scope>compile</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.jena</groupId>
-			<artifactId>jena-core</artifactId>
-			<version>5.4.0</version>
-			<scope>compile</scope>
-		</dependency>
 	</dependencies>
     <build>
   		<resources>

--- a/src/main/java/org/spdx/tools/SpdxToolsHelper.java
+++ b/src/main/java/org/spdx/tools/SpdxToolsHelper.java
@@ -389,7 +389,7 @@ public class SpdxToolsHelper {
 			throw new InvalidSPDXAnalysisException("No SPDX version 3 documents in model store");
 		}
 		if (docs.size() > 1) {
-			throw new InvalidSPDXAnalysisException("Multiple SPDX version 3 documents in modelSTore.  There can only be one SPDX document.");
+			throw new InvalidSPDXAnalysisException("Multiple SPDX version 3 documents in modelStore.  There can only be one SPDX document.");
 		}
 		return docs.get(0);
 	}


### PR DESCRIPTION
These dependencies are included as transitive dependencies through other SPDX library modules.  Removing these from the POM file to avoid possible version conflicts.

This commit also includes a fix to a minor typo.