### PR TITLE
Fix deprecated isLicenseCommmentsEquals

### DIFF
--- a/src/main/java/org/spdx/tools/Verify.java
+++ b/src/main/java/org/spdx/tools/Verify.java
@@ -26,7 +26,6 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import java.util.Set;
 
 import com.fasterxml.jackson.core.JsonParseException;
 

--- a/src/main/java/org/spdx/tools/compare/PackageSheet.java
+++ b/src/main/java/org/spdx/tools/compare/PackageSheet.java
@@ -296,7 +296,7 @@ public class PackageSheet extends AbstractSheet {
 		}
 		Row licenseCommentRow = this.addRow();
 		licenseCommentRow.createCell(FIELD_COL).setCellValue(LICENSE_COMMENT_FIELD_TEXT);
-		if (comparer.isLicenseCommmentsEquals()) {
+		if (comparer.isLicenseCommentsEquals()) {
 			setCellEqualValue(licenseCommentRow.createCell(EQUALS_COL), allDocsPresent);
 		} else {
 			setCellDifferentValue(licenseCommentRow.createCell(EQUALS_COL));

--- a/src/main/java/org/spdx/tools/compare/SnippetSheet.java
+++ b/src/main/java/org/spdx/tools/compare/SnippetSheet.java
@@ -196,7 +196,7 @@ public class SnippetSheet extends AbstractSheet {
 		}
 		Row licenseCommentRow = this.addRow();
 		licenseCommentRow.createCell(FIELD_COL).setCellValue(LICENSE_COMMENT_FIELD_TEXT);
-		if (comparer.isLicenseCommmentsEquals()) {
+		if (comparer.isLicenseCommentsEquals()) {
 			setCellEqualValue(licenseCommentRow.createCell(EQUALS_COL), allDocsPresent);
 		} else {
 			setCellDifferentValue(licenseCommentRow.createCell(EQUALS_COL));

--- a/testResources/sourcefiles/PackageSheet.java
+++ b/testResources/sourcefiles/PackageSheet.java
@@ -294,7 +294,7 @@ public class PackageSheet extends AbstractSheet {
 		}
 		Row licenseCommentRow = this.addRow();
 		licenseCommentRow.createCell(FIELD_COL).setCellValue(LICENSE_COMMENT_FIELD_TEXT);
-		if (comparer.isLicenseCommmentsEquals()) {
+		if (comparer.isLicenseCommentsEquals()) {
 			setCellEqualValue(licenseCommentRow.createCell(EQUALS_COL), allDocsPresent);
 		} else {
 			setCellDifferentValue(licenseCommentRow.createCell(EQUALS_COL));

--- a/testResources/sourcefiles/SnippetSheet.java
+++ b/testResources/sourcefiles/SnippetSheet.java
@@ -196,7 +196,7 @@ public class SnippetSheet extends AbstractSheet {
 		}
 		Row licenseCommentRow = this.addRow();
 		licenseCommentRow.createCell(FIELD_COL).setCellValue(LICENSE_COMMENT_FIELD_TEXT);
-		if (comparer.isLicenseCommmentsEquals()) {
+		if (comparer.isLicenseCommentsEquals()) {
 			setCellEqualValue(licenseCommentRow.createCell(EQUALS_COL), allDocsPresent);
 		} else {
 			setCellDifferentValue(licenseCommentRow.createCell(EQUALS_COL));


### PR DESCRIPTION
- Uses isLicenseCommentsEquals (2 m),
  instead of isLicenseCommmentsEquals (3 m).

- Remove unused import java.util.Set in src/main/java/org/spdx/tools/Verify.java