### PR TITLE
Revert json-schema-validator version to 1.5.9

### DIFF
--- a/examples/org/spdx/examples/ExpandedLicenseExampleV3.java
+++ b/examples/org/spdx/examples/ExpandedLicenseExampleV3.java
@@ -3,7 +3,7 @@
  * SPDX-FileCopyrightText: Copyright (c) 2025 Source Auditor Inc.
  * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
- *
+ * <br/>
  * Example of serializing a single expanded license
  */
 
@@ -12,10 +12,10 @@ package org.spdx.examples;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
-import com.networknt.schema.Error;
-import com.networknt.schema.Schema;
-import com.networknt.schema.SchemaRegistry;
-import com.networknt.schema.SpecificationVersion;
+import com.networknt.schema.JsonSchema;
+import com.networknt.schema.JsonSchemaFactory;
+import com.networknt.schema.SpecVersion.VersionFlag;
+import com.networknt.schema.ValidationMessage;
 import org.spdx.core.DefaultModelStore;
 import org.spdx.core.IModelCopyManager;
 import org.spdx.library.LicenseInfoFactory;
@@ -37,6 +37,7 @@ import java.io.*;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 
 import static org.spdx.tools.Verify.JSON_SCHEMA_RESOURCE_V3;
 
@@ -158,18 +159,17 @@ public class ExpandedLicenseExampleV3 {
             try (OutputStream outStream = new FileOutputStream(outFile)) {
                 modelStore.serialize(outStream, doc);
             }
-            SchemaRegistry schemaRegistry =
-                    SchemaRegistry.withDefaultDialect(SpecificationVersion.DRAFT_2020_12);
-            Schema schema;
+            JsonSchemaFactory jsonSchemaFactory = JsonSchemaFactory.getInstance(VersionFlag.V202012);
+            JsonSchema schema;
             try (InputStream is = Verify.class.getResourceAsStream("/" + JSON_SCHEMA_RESOURCE_V3)) {
-                schema = schemaRegistry.getSchema(is);
+                schema = jsonSchemaFactory.getSchema(is);
             }
             JsonNode root;
             try (InputStream is = new FileInputStream(outFile)) {
                 root = JSON_MAPPER.readTree(is);
             }
-            List<com.networknt.schema.Error> messages = schema.validate(root);
-            for (Error msg:messages) {
+            Set<ValidationMessage> messages = schema.validate(root);
+            for (ValidationMessage msg:messages) {
                 warnings.add(msg.toString());
             }
             if (!warnings.isEmpty()) {

--- a/examples/org/spdx/examples/FullSpdxV3Example.java
+++ b/examples/org/spdx/examples/FullSpdxV3Example.java
@@ -3,7 +3,7 @@
  * SPDX-FileCopyrightText: Copyright (c) 2025 Source Auditor Inc.
  * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
- *
+ * <br/>
  * Full example of an SPDX document using all classes
  */
 
@@ -12,10 +12,10 @@ package org.spdx.examples;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
-import com.networknt.schema.Error;
-import com.networknt.schema.Schema;
-import com.networknt.schema.SchemaRegistry;
-import com.networknt.schema.SpecificationVersion;
+import com.networknt.schema.JsonSchema;
+import com.networknt.schema.JsonSchemaFactory;
+import com.networknt.schema.SpecVersion.VersionFlag;
+import com.networknt.schema.ValidationMessage;
 import org.spdx.core.DefaultModelStore;
 import org.spdx.core.IModelCopyManager;
 import org.spdx.core.InvalidSPDXAnalysisException;
@@ -838,18 +838,17 @@ public class FullSpdxV3Example {
             }
 
             // Validate using the schema
-            SchemaRegistry schemaRegistry =
-                    SchemaRegistry.withDefaultDialect(SpecificationVersion.DRAFT_2020_12);
-            Schema schema;
+            JsonSchemaFactory jsonSchemaFactory = JsonSchemaFactory.getInstance(VersionFlag.V202012);
+            JsonSchema schema;
             try (InputStream is = Verify.class.getResourceAsStream("/" + JSON_SCHEMA_RESOURCE_V3)) {
-                schema = schemaRegistry.getSchema(is);
+                schema = jsonSchemaFactory.getSchema(is);
             }
             JsonNode root;
             try (InputStream is = new FileInputStream(outFile)) {
                 root = JSON_MAPPER.readTree(is);
             }
-            List<Error> messages = schema.validate(root);
-            for (Error msg:messages) {
+            Set<ValidationMessage> messages = schema.validate(root);
+            for (ValidationMessage msg:messages) {
                 warnings.add(msg.toString());
             }
             if (!warnings.isEmpty()) {

--- a/pom.xml
+++ b/pom.xml
@@ -148,7 +148,7 @@
 	  <dependency>
 	  	<groupId>com.networknt</groupId>
 	  	<artifactId>json-schema-validator</artifactId>
-	  	<version>2.0.0</version>
+	  	<version>1.5.9</version>
 	  </dependency>
 	  <dependency>
 	  	<groupId>org.slf4j</groupId>

--- a/src/main/java/org/spdx/tools/Verify.java
+++ b/src/main/java/org/spdx/tools/Verify.java
@@ -2,13 +2,13 @@
  * SPDX-FileCopyrightText: Copyright (c) 2015 Source Auditor Inc.
  * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
- *
+ * <br/>
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
  *   You may obtain a copy of the License at
- *
+ * <br/>
  *       https://www.apache.org/licenses/LICENSE-2.0
- *
+ * <br/>
  *   Unless required by applicable law or agreed to in writing, software
  *   distributed under the License is distributed on an "AS IS" BASIS,
  *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -26,6 +26,7 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 
 import com.fasterxml.jackson.core.JsonParseException;
 
@@ -39,10 +40,11 @@ import org.spdx.tools.SpdxToolsHelper.SerFileType;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
-import com.networknt.schema.Schema;
-import com.networknt.schema.SchemaRegistry;
-import com.networknt.schema.SpecificationVersion;
-import com.networknt.schema.Error;
+
+import com.networknt.schema.JsonSchema;
+import com.networknt.schema.JsonSchemaFactory;
+import com.networknt.schema.SpecVersion.VersionFlag;
+import com.networknt.schema.ValidationMessage;
 
 /**
  * Verifies an SPDX document and lists any verification errors
@@ -171,18 +173,17 @@ public class Verify {
 				} else {
 					jsonSchemaResource = JSON_SCHEMA_RESOURCE_V3;
 				}
-				SchemaRegistry schemaRegistry =
-						SchemaRegistry.withDefaultDialect(SpecificationVersion.DRAFT_2020_12);
-				Schema schema;
+				JsonSchemaFactory jsonSchemaFactory = JsonSchemaFactory.getInstance(VersionFlag.V202012);
+				JsonSchema schema;
 				try (InputStream is = Verify.class.getResourceAsStream("/" + jsonSchemaResource)) {
-					schema = schemaRegistry.getSchema(is);
+					schema = jsonSchemaFactory.getSchema(is);
 				}
 				JsonNode root;
 				try (InputStream is = new FileInputStream(file)) {
 					root = JSON_MAPPER.readTree(is);
 				}
-				List<Error> messages = schema.validate(root);
-				for (Error msg:messages) {
+				Set<ValidationMessage> messages = schema.validate(root);
+				for (ValidationMessage msg:messages) {
 					retval.add(msg.toString());
 				}
 			} catch (IOException e) {


### PR DESCRIPTION
Fixes #257

Version 2.0.0 of the json-schema-validator introduces a very significant performance degredation