### PR TITLE
Fix TOOLS_JAVA_VERSION export in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,30 +1,35 @@
 # syntax=docker/dockerfile:1.4
 
+# SPDX-FileCopyrightText: Copyright (c) 2023 Source Auditor Inc.
+# SPDX-FileType: SOURCE
+# SPDX-License-Identifier: Apache-2.0
+
 # Set Java versions
 ARG JAVA_VERSION=21
 
 # Use Maven eclipse Temurin based
-FROM maven:3.9-eclipse-temurin-$JAVA_VERSION as build
+FROM maven:3.9-eclipse-temurin-$JAVA_VERSION AS build
 
 WORKDIR /build
 
+# Copy the wrapper script, @@VERSION@@ to be replaced below
+COPY scripts/tools-java-wrapper.sh /usr/bin/tools-java
+
 # BUILD
+# NOTE: TOOLS_JAVA_VERSION must be exported and used within single RUN.
+# Env vars set with `export` do not persist across separate RUN layers.
 RUN --mount=type=cache,target=/root/.m2 \
-    --mount=type=bind,source=$PWD,target=/build,rw \
+    --mount=type=bind,target=/build,rw \
+    # bind source defaults to the build context, expected to be the repo root
     export TOOLS_JAVA_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout) \
     && mvn clean org.jacoco:jacoco-maven-plugin:prepare-agent install \
     && mkdir -p /usr/lib/java/spdx \
-    && cp target/tools-java-$TOOLS_JAVA_VERSION-jar-with-dependencies.jar /usr/lib/java/spdx/
-
-# Configure the wrapper script
-COPY scripts/tools-java-wrapper.sh /usr/bin/tools-java
-
-# Make the bwrapper match tools version
-RUN sed -i "s/@@VERSION@@/$TOOLS_JAVA_VERSION/g" /usr/bin/tools-java \
+    && cp target/tools-java-$TOOLS_JAVA_VERSION-jar-with-dependencies.jar /usr/lib/java/spdx/ \
+    && sed -i "s/@@VERSION@@/$TOOLS_JAVA_VERSION/g" /usr/bin/tools-java \
     && chmod +x /usr/bin/tools-java
 
 # Deploy image
-FROM eclipse-temurin:$JAVA_VERSION as run
+FROM eclipse-temurin:$JAVA_VERSION AS run
 
 COPY --from=build /usr/lib/java/spdx /usr/lib/java/spdx
 COPY --from=build /usr/bin/tools-java /usr/bin/tools-java


### PR DESCRIPTION
- In Dockerfile, env vars in one RUN didn't last to another RUN.
  So in our case, `TOOLS_JAVA_VERSION` is lost and breaks the `@@VERSION@@` substitution for the `scripts/tools-java-wrapper.sh` -- producing `tools-java--jar-with-dependencies.jar` (missing version, double dash), causing error.
- Removes no-op `source=$PWD` on the bind mount.
  $PWD is not a recognized variable in Dockerfile, always empty.
  (No change in behavior, as default is the build context root. Just a cleanup to avoid confusion)

To fix #295