### PR TITLE
Fix "Log4j API could not find a logging provider"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -161,6 +161,11 @@
 	  	<version>2.0.18</version>
 	  	<optional>true</optional>
 	  </dependency>
+	  <dependency>
+	  	<groupId>org.apache.logging.log4j</groupId>
+	  	<artifactId>log4j-to-slf4j</artifactId>
+	  	<version>2.26.1</version>
+	  </dependency>
 	</dependencies>
     <build>
   		<resources>


### PR DESCRIPTION
When running `mvn verify`, got this error message:

> main ERROR Log4j API could not find a logging provider.

Apache POI (used by the spreadsheet store) uses `log4j-api`.
Our project uses `slf4j-simple` provider, so add `log4j-to-slf4j` as adapter, to fix the error.